### PR TITLE
Added meaningful page when no devices discovered

### DIFF
--- a/public/javascripts/dash.js
+++ b/public/javascripts/dash.js
@@ -11,7 +11,9 @@ var dash = {
   init: function(deviceId) {
     this.deviceId = deviceId;
 
-    $('.' + deviceId).addClass('active');
+    if (this.deviceId) {
+      $('.' + deviceId).addClass('active');
+    }
 
     this.initRealtimeGauge();
     this.initRealtimeTrendChart();

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,9 +5,15 @@ const deviceManager = require('../services/device-manager');
 
 router.get('/', function(req, res, next) {
 
-  let deviceId = sortDevices(deviceManager.getAllDevices())[0].deviceId;
+  let devices = sortDevices(deviceManager.getAllDevices());
 
-  res.redirect('/' + deviceId);
+  if (devices && devices.length > 0) {
+    let deviceId = devices[0].deviceId;
+
+    res.redirect('/' + deviceId);
+  } else {
+    res.render('index', {});
+  }
 
 });
 

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -21,6 +21,13 @@
                     {{this.alias}}
                   </a>
                 </li>
+                {{else}}
+                <li>
+                  <a href='index.html'>
+                    <i class="fa fa-info"></i>
+                    no devices discovered yet
+                  </a>
+                </li>
                 {{/each}}
               </ul>
             </div>
@@ -41,6 +48,13 @@
                   <a title="Device Id: {{this.deviceId}}" href="/{{this.deviceId}}">
                     <i class="fa fa-plug"></i>
                     {{this.alias}}
+                  </a>
+                </li>
+                {{else}}
+                <li>
+                  <a href="index.html">
+                    <i class="fa fa-info"></i>
+                    no devices discovered yet
                   </a>
                 </li>
                 {{/each}}


### PR DESCRIPTION
In the current version, when no device is discovered on the network, it just shows a stacktrace.

I changed it to show the index-page, but with a small info where normally the devices would be listed.