### PR TITLE
Fix voltage reading and exclude unsupported devices from search

### DIFF
--- a/services/device-manager.js
+++ b/services/device-manager.js
@@ -7,12 +7,19 @@ var devices = [];
 client.startDiscovery({
     deviceTypes: ['plug'],
     discoveryTimeout: 20000
-  }).on('plug-new', plug => {
-  console.log('Found device: ' + plug.alias + ' [' + plug.deviceId + ']');
-  devices.push(plug);
+  }).on('plug-new', registerPlug);
 
-  dataLogger.startLogging(plug);
-});
+function registerPlug(plug) {
+  
+  if (plug.supportsEmeter) {
+    console.log('Found device with energy monitor support: ' + plug.alias + ' [' + plug.deviceId + ']');
+    devices.push(plug);
+    dataLogger.startLogging(plug);
+  } else {
+    console.log('Skipping device: ' + plug.alias + ' [' + plug.deviceId + ']. Energy monitoring not supported.');
+  }
+  
+}
 
 module.exports.getDevice = function(deviceId) {
 


### PR DESCRIPTION
- Don't apply the RMS voltage calculation for devices with newer firmware, as they now supply the voltage data measured as RMS already. 
- When scanning and registering plugs to monitor, skip any which do not support the energy monitoring API. Previously any HS100 devices found would get registered and subsequent energy usage data requests would continuously fail.

