### PR TITLE
Discover devices on all local interfaces

### DIFF
--- a/services/device-manager.js
+++ b/services/device-manager.js
@@ -1,13 +1,25 @@
 const { Client } = require('tplink-smarthome-api');
 const dataLogger = require('./data-logger');
+const interfaces = require('os').networkInterfaces();
 
-const client = new Client();
 var devices = [];
 
-client.startDiscovery({
+function startDiscovery(bindAddress) {
+  console.log('Starting discovery on interface: ' + bindAddress);
+  var client = new Client();
+  client.startDiscovery({
     deviceTypes: ['plug'],
+    address: bindAddress,
     discoveryTimeout: 20000
-  }).on('plug-new', registerPlug);
+  }).on('plug-new', registerPlug);  
+}
+
+Object.keys(interfaces)
+  .reduce((results, name) => results.concat(interfaces[name]), [])
+  .filter((iface) => iface.family === 'IPv4' && !iface.internal)
+  .map((iface) => iface.address)
+  .map(startDiscovery);
+
 
 function registerPlug(plug) {
   


### PR DESCRIPTION
A solution for device discovery defaulting to the wrong local interface  (my PC has 4 local interfaces for VMs, etc).

My Javascript is about 10 years out of date, so I'm sure there is a nicer way to do this, but it's a start.