### PR TITLE
Make low power readings more precise

### DIFF
--- a/public/javascripts/dash.js
+++ b/public/javascripts/dash.js
@@ -275,7 +275,7 @@ var dash = {
 
   refreshRealtimeDisplay: function(realtime) {
 
-    var power = Math.round(('power_mw' in realtime) ? (realtime.power_mw/1000) : realtime.power);
+    var power = (('power_mw' in realtime) ? (realtime.power_mw/1000) : realtime.power).toPrecision(3);
     var current = (('current_ma' in realtime) ? (realtime.current_ma/1000) : realtime.current).toFixed(2);
     var voltage = Math.round(('voltage_mv' in realtime) ? (realtime.voltage_mv/1000) : realtime.voltage);
 


### PR DESCRIPTION
For assessing stand-by power, this makes for a less jumpy graph.
Before:
![image](https://user-images.githubusercontent.com/2952027/65790011-e2d07b00-e15e-11e9-86cb-9815fc3e9423.png)
After:
![image](https://user-images.githubusercontent.com/2952027/65790100-26c38000-e15f-11e9-8c87-96a8667139dc.png)
