### PR TITLE
choose web socket scheme based on window.location.protocol

### DIFF
--- a/public/javascripts/dash.js
+++ b/public/javascripts/dash.js
@@ -26,7 +26,8 @@ var dash = {
   },
 
   initWsConnection: function() {
-    var wsUri = 'ws://' + window.location.host + '/ws'
+    var scheme = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+    var wsUri = scheme + window.location.host + '/ws';
     var ws = new WebSocket(wsUri);
     ws.onopen = function () {
       console.log('Websocket connection established');


### PR DESCRIPTION
This PR allows the application to be accessed via https by testing the protocol being used as `https:` and then setting the web socket scheme to `wss` instead of `ws`.

For example, I have an nginx server in front of my tplink-energy-monitor app.  I was receiving Console errors like this:  
![image](https://user-images.githubusercontent.com/290154/68651216-f0667800-04f4-11ea-9a2d-dcce07195d65.png)

